### PR TITLE
Bump version to 4.1.4; finalize device refresh, player teardown, and playlist auth/error handling

### DIFF
--- a/SpotifyWPF/SpotifyWPF.csproj
+++ b/SpotifyWPF/SpotifyWPF.csproj
@@ -16,9 +16,9 @@
     <!-- Metadati assembly centralizzati -->
     <Company>SpotifyWPF</Company>
     <Product>SpotifyWPF</Product>
-  <AssemblyVersion>4.1.3.0</AssemblyVersion>
-  <FileVersion>4.1.3.0</FileVersion>
-  <Version>4.1.3</Version>
+  <AssemblyVersion>4.1.4.0</AssemblyVersion>
+  <FileVersion>4.1.4.0</FileVersion>
+  <Version>4.1.4</Version>
     <Authors>SpotifyWPF</Authors>
     <!-- Riattiva generazione attributi per evitare assembly info duplicati manuali -->
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/SpotifyWPF/ViewModel/Component/DeviceManager.cs
+++ b/SpotifyWPF/ViewModel/Component/DeviceManager.cs
@@ -99,7 +99,7 @@ namespace SpotifyWPF.ViewModel.Component
         /// <summary>
         /// Refresh available devices from Spotify API
         /// </summary>
-        public async Task RefreshDevicesAsync()
+        public async Task RefreshDevicesAsync(bool notifySubscribers = true)
         {
             if (_isRefreshingDevices) return;
             _isRefreshingDevices = true;
@@ -208,14 +208,17 @@ namespace SpotifyWPF.ViewModel.Component
                     SelectedDevice = active;
                 }
 
-                // Notify interested parties (UI/menu) that devices changed
-                // Let MainViewModel know the device menu should be refreshed (also used for diagnostics)
-                try
+                if (notifySubscribers)
                 {
-                    // Use VM shim to send a global message for device list changes
-                    GalaSoft.MvvmLight.Messenger.Default.Send<object>(new object(), SpotifyWPF.ViewModel.MessageType.DevicesUpdated);
+                    // Notify interested parties (UI/menu) that devices changed
+                    // Let MainViewModel know the device menu should be refreshed (also used for diagnostics)
+                    try
+                    {
+                        // Use VM shim to send a global message for device list changes
+                        GalaSoft.MvvmLight.Messenger.Default.Send<object>(new object(), SpotifyWPF.ViewModel.MessageType.DevicesUpdated);
+                    }
+                    catch { }
                 }
-                catch { }
             }
             catch (Exception ex)
             {

--- a/SpotifyWPF/ViewModel/PlayerViewModel.cs
+++ b/SpotifyWPF/ViewModel/PlayerViewModel.cs
@@ -140,7 +140,7 @@ namespace SpotifyWPF.ViewModel
 
             // Subscribe to Web Playback events — delegate state processing to PlayerStateService
             _playerStateService = new Component.PlayerStateService(_deviceManager, _timerManager, _loggingService, UpdateUIFromPlayerState);
-            _webPlaybackBridge.OnPlayerStateChanged += state => _playerStateService.ProcessIncomingState(state);
+            _webPlaybackBridge.OnPlayerStateChanged += OnPlayerStateChanged;
             _playerStateService.OnProcessedState += PlayerStateService_OnProcessedState;
             _playerUiAdapter = new Component.PlayerUIAdapter(_loggingService);
             _playerUiAdapter.AlbumArtReady += img =>
@@ -180,7 +180,7 @@ namespace SpotifyWPF.ViewModel
                         try
                         {
                             _loggingService.LogDebug("[MSG] DevicesUpdated received — triggering quick state refresh");
-                            await _deviceManager.RefreshDevicesAsync();
+                            await _deviceManager.RefreshDevicesAsync(notifySubscribers: false);
                             await RefreshPlayerStateAsync();
                         }
                         catch (Exception ex)
@@ -2461,6 +2461,7 @@ namespace SpotifyWPF.ViewModel
                 {
                     if (_webPlaybackBridge != null)
                     {
+                        _webPlaybackBridge.OnPlayerStateChanged -= OnPlayerStateChanged;
                         _webPlaybackBridge.OnAccountError -= OnAccountError;
                     }
                 }
@@ -2472,6 +2473,22 @@ namespace SpotifyWPF.ViewModel
                     _tokenProvider.AccessTokenRefreshed -= OnAccessTokenRefreshed;
                 }
                 catch { }
+
+                try
+                {
+                    MessengerInstance.Unregister<object>(this, MessageType.DevicesUpdated);
+                    MessengerInstance.Unregister<SpotifyWPF.ViewModel.Messages.PlaybackUpdatePayload>(this, MessageType.PlaybackUpdated);
+                }
+                catch { }
+
+                try
+                {
+                    _deviceManager?.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    _loggingService?.LogError($"Error disposing DeviceManager in PlayerViewModel.Dispose: {ex.Message}", ex);
+                }
             }
 
             _disposed = true;


### PR DESCRIPTION
### Motivation
- Prevent recursive device-refresh broadcasts and noisy refresh loops when device updates are propagated.  
- Ensure `PlayerViewModel` cleans up subscriptions and disposes `DeviceManager` to avoid leaked handlers and inconsistent state.  
- Make playlist loading robust to missing/expired credentials, permission errors, and rate limits so users see actionable messages.  
- Ship these fixes with an updated package/assembly version metadata.

### Description
- Add a `notifySubscribers` parameter to `DeviceManager.RefreshDevicesAsync` and only broadcast `MessageType.DevicesUpdated` when `notifySubscribers` is `true`, avoiding rebroadcast loops (`SpotifyWPF/ViewModel/Component/DeviceManager.cs`).
- Change `PlayerViewModel` to call `RefreshDevicesAsync(notifySubscribers: false)` on quick refreshes, replace the inline lambda WebPlayback handler with a named `OnPlayerStateChanged` handler, unregister event handlers and messenger registrations on dispose, and attempt to dispose `_deviceManager` (`SpotifyWPF/ViewModel/PlayerViewModel.cs`).
- Harden `PlaylistsPageViewModel.LoadPlaylistsAsync` to call `EnsureAuthenticatedAsync()` before loading, rethrow `ForbiddenException`/`UnauthorizedAccessException` from page fetch attempts so they are handled centrally, and add user-facing `MessageBox` dialogs for permission, session-expired, network, rate-limit, and unexpected errors (`SpotifyWPF/ViewModel/Page/PlaylistsPageViewModel.cs`).
- Bump project version metadata in `SpotifyWPF/SpotifyWPF.csproj` from `4.1.3` to `4.1.4` (`<AssemblyVersion>`, `<FileVersion>`, and `<Version>`).