### PR TITLE
Add Messenger.Unregister shim and fix PlayerViewModel disposal & related fixes

### DIFF
--- a/SpotifyWPF/Compatibility/MvvmLightShim.cs
+++ b/SpotifyWPF/Compatibility/MvvmLightShim.cs
@@ -40,6 +40,11 @@ namespace GalaSoft.MvvmLight
             var tk = token?.ToString() ?? string.Empty;
             _inner.Send<T, string>(message, tk);
         }
+
+        public void Unregister(object recipient)
+        {
+            _inner.UnregisterAll(recipient);
+        }
     }
 }
 

--- a/SpotifyWPF/SpotifyWPF.csproj
+++ b/SpotifyWPF/SpotifyWPF.csproj
@@ -16,9 +16,9 @@
     <!-- Metadati assembly centralizzati -->
     <Company>SpotifyWPF</Company>
     <Product>SpotifyWPF</Product>
-  <AssemblyVersion>4.1.3.0</AssemblyVersion>
-  <FileVersion>4.1.3.0</FileVersion>
-  <Version>4.1.3</Version>
+  <AssemblyVersion>4.1.4.0</AssemblyVersion>
+  <FileVersion>4.1.4.0</FileVersion>
+  <Version>4.1.4</Version>
     <Authors>SpotifyWPF</Authors>
     <!-- Riattiva generazione attributi per evitare assembly info duplicati manuali -->
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/SpotifyWPF/ViewModel/Component/DeviceManager.cs
+++ b/SpotifyWPF/ViewModel/Component/DeviceManager.cs
@@ -99,7 +99,7 @@ namespace SpotifyWPF.ViewModel.Component
         /// <summary>
         /// Refresh available devices from Spotify API
         /// </summary>
-        public async Task RefreshDevicesAsync()
+        public async Task RefreshDevicesAsync(bool notifySubscribers = true)
         {
             if (_isRefreshingDevices) return;
             _isRefreshingDevices = true;
@@ -208,14 +208,17 @@ namespace SpotifyWPF.ViewModel.Component
                     SelectedDevice = active;
                 }
 
-                // Notify interested parties (UI/menu) that devices changed
-                // Let MainViewModel know the device menu should be refreshed (also used for diagnostics)
-                try
+                if (notifySubscribers)
                 {
-                    // Use VM shim to send a global message for device list changes
-                    GalaSoft.MvvmLight.Messenger.Default.Send<object>(new object(), SpotifyWPF.ViewModel.MessageType.DevicesUpdated);
+                    // Notify interested parties (UI/menu) that devices changed
+                    // Let MainViewModel know the device menu should be refreshed (also used for diagnostics)
+                    try
+                    {
+                        // Use VM shim to send a global message for device list changes
+                        GalaSoft.MvvmLight.Messenger.Default.Send<object>(new object(), SpotifyWPF.ViewModel.MessageType.DevicesUpdated);
+                    }
+                    catch { }
                 }
-                catch { }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Motivation
- Fix a compile error where code called `MessengerInstance.Unregister(this)` but the MVVM Light shim lacked an `Unregister` API, and improve cleanup and error handling around player/device/playlists flows.
- Prevent unintended message loops when refreshing devices from the player and ensure components fully unsubscribe and dispose to avoid leaks and runtime issues.
- Improve robustness of playlist loading by surfacing authentication/HTTP/rate-limit errors to the user and handling them gracefully.

### Description
- Added `Unregister(object recipient)` to `SpotifyWPF/Compatibility/MvvmLightShim.cs` which calls the underlying `WeakReferenceMessenger.UnregisterAll(recipient)` so `MessengerInstance.Unregister(this)` compiles and unregisters all handlers.
- Updated `PlayerViewModel` to use a named `OnPlayerStateChanged` handler, unsubscribe it during `Dispose`, call `MessengerInstance.Unregister(this)` in `Dispose`, and dispose `_deviceManager` with error logging during cleanup.
- Changed device refresh behavior: `DeviceManager.RefreshDevicesAsync` gained a `notifySubscribers` parameter (default `true`) and callers (PlayerViewModel) now call `RefreshDevicesAsync(notifySubscribers: false)` to avoid re-broadcasting device updates that would re-trigger refresh loops.
- Hardened `PlaylistsPageViewModel.LoadPlaylistsAsync` with an authentication check using `EnsureAuthenticatedAsync`, added user-facing `MessageBox` notifications for login, rate-limit, forbidden/unauthorized, and network errors, and improved exception handling to avoid swallowing important errors.
- Bumped assembly/product version values in `SpotifyWPF/SpotifyWPF.csproj` (from 4.1.3 -> 4.1.4) and updated some package references.

### Testing
- Performed static verification with code search (`rg`) to find `MessengerInstance` usage sites and confirm the shim covers existing callsites (succeeded).
- No full `dotnet build` or CI run was executed in this environment, so no compile or unit test run was performed here (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697779b4f05c832f9e9fbc9ac25bbd1f)